### PR TITLE
Fix implicit declaration of inet_addr

### DIFF
--- a/server_main.c
+++ b/server_main.c
@@ -2,7 +2,7 @@
 
 #include <stdio.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <string.h>
 
 int main(){


### PR DESCRIPTION
The inet_addr() function converts the internet host address cp from IPV4 numbers-and-dots notation into binary data in network byte order. If the input is invalid, INADDR_NONE(-1) is returned. But use of this function sometimes can be problematic because -1 represents 255.255.255.255. You should avoid its use in favor of inet_aton(), inet_pton() or getaddrinfo()

But to fix the error:

```
implicit declaration of function 'inet_addr' is invalid in C99 [-Wimplicit-function-declaration]
    serv.sin_addr.s_addr = inet_addr(argv[1]);
```


You should add “#include <arpa/inet.h>” to the main.h file or any header file included. 

From : https://www.lixu.ca/2014/09/c-implicit-declaration-of-function.html